### PR TITLE
Fix Remember Me preference persistence

### DIFF
--- a/src/storage.js
+++ b/src/storage.js
@@ -34,7 +34,7 @@ export function loadConfig() {
       return {
         apiUrl: config.apiUrl || "",
         apiToken: config.apiToken || "",
-        remember: config.remember || true,
+        remember: config.remember ?? true,
         refreshInterval: config.refreshInterval || 10,
         theme: config.theme || 'dark'
       };
@@ -50,7 +50,7 @@ export function loadConfig() {
       return {
         apiUrl: config.apiUrl || "",
         apiToken: config.apiToken || "",
-        remember: config.remember || true,
+        remember: config.remember ?? true,
         refreshInterval: config.refreshInterval || 10,
         theme: config.theme || 'dark'
       };


### PR DESCRIPTION
### Motivation
- A `|| true` normalization in `loadConfig()` coerced an explicit `remember: false` into `true`, causing the Settings checkbox to appear checked and session credentials to be saved to `localStorage` unintentionally.
- The intent is to preserve an explicit `false` while still defaulting to `true` only when the property is absent or `null`/`undefined`.

### Description
- Updated `src/storage.js` in `loadConfig()` to use the nullish coalescing operator `config.remember ?? true` instead of `config.remember || true` so that explicit `false` values are preserved.
- The change is applied in both the `localStorage` and `sessionStorage` code paths so session-only credentials remain non-persistent when the user did not opt into remembering.

### Testing
- Executed a Node-based regression script that stubs `localStorage` and `sessionStorage`, stores objects with `remember: false`, and verifies `loadConfig()` returns `remember: false` for both backends, and the test succeeded.
- Ran a quick automated diff/check (`git diff --check`) to ensure there are no trailing whitespace or diff issues and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5970f98570832b89d1e4668f623035)