### PR TITLE
fix: properly escape double quotes in escapeHtml function

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -473,7 +473,7 @@ function escapeHtml(str) {
     .replace(/&/g, "&")
     .replace(/</g, "<")
     .replace(/>/g, ">")
-    .replace(/\"/g, "\"")
+    .replace(/"/g, "&quot;");
     .replace(/'/g, "&#039;");
 }
 


### PR DESCRIPTION
- Replace broken .replace(/"/g, "") with correct .replace(/"+/g, "&")"}