### PR TITLE
fix: code review findings (escapeHtml XSS, fetch abort, modal cleanup)

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -14,10 +14,14 @@ import { getConfig } from "./storage.js";
 /**
  * Helper to create a timeout‑aware promise.
  */
-function timeoutPromise(ms) {
-  return new Promise((_, reject) =>
-    setTimeout(() => reject(new Error("Request timed out")), ms)
-  );
+function createTimeoutController(ms) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), ms);
+  // Caller is responsible for clearTimeout in the finally block via the
+  // `timer` we expose on the controller -- wrap separately so the timer
+  // is always cleaned up.
+  controller._timer = timer;
+  return controller;
 }
 
 /**
@@ -36,7 +40,9 @@ export async function request(path, options = {}) {
   const url = new URL(path, cfg.apiUrl).toString();
   const headers = new Headers(options.headers || {});
   // Mask token in logs – do not expose raw value.
-  const maskedToken = cfg.apiToken.replace(/./g, "*");
+  // Fixed-length mask: a per-char '*' reveals the token length to anyone
+  // who happens to scrape the console. Keep this constant.
+  const maskedToken = "**********";
   console.debug(`API request → ${url} – Authorization: Bearer ${maskedToken}`);
   headers.set("Authorization", `Bearer ${cfg.apiToken}`);
 
@@ -46,9 +52,16 @@ export async function request(path, options = {}) {
     headers,
   };
 
+  // 8‑second timeout for the XMRig‑Proxy request. We use a real AbortController
+  // so the underlying fetch is cancelled when the timeout fires -- the
+  // previous Promise.race handler rejected the wrapper but left the
+  // connection draining in the background.
+  const timeoutController = createTimeoutController(8000);
   try {
-    // 8‑second timeout for the XMRig‑Proxy request.
-    const response = await Promise.race([fetch(url, fetchOpts), timeoutPromise(8000)]);
+    const response = await fetch(url, {
+      ...fetchOpts,
+      signal: timeoutController.signal,
+    });
     if (!response.ok) {
       // 401 / 403 trigger a logout flow upstream.
       const err = new Error(`HTTP ${response.status}`);
@@ -58,11 +71,14 @@ export async function request(path, options = {}) {
     const data = await response.json();
     return data;
   } catch (e) {
-    // Normalise network errors.
+    // AbortError may come from either an explicit caller abort or our
+    // timeout firing -- normalise the timeout case to a friendlier message.
     if (e.name === "AbortError") {
-      e.message = "Network request aborted";
+      e.message = "Request timed out";
     }
     console.error(`API error (masked): ${e.message}`);
     throw e;
+  } finally {
+    clearTimeout(timeoutController._timer);
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -241,7 +241,7 @@ function renderDashboard(data) {
         <div class="card-title">活跃矿工</div>
         <div class="card-value ${data.miners?.now > 0 ? "highlight-green" : "highlight-red"}">${formatNumber(data.miners?.now || 0)}</div>
         <div class="card-label">峰值: ${formatNumber(data.miners?.max || 0)} 矿工</div>
-        <div class="progress-bar"><div class="progress-fill" style="width:${data.miners?.max ? (data.miners.now/data.miners.max*100).toFixed(1) : 0}%"></div></div>
+        <div class="progress-bar"><div class="progress-fill" style="width:${(data.miners?.max ? Math.min(100, Math.max(0, (data.miners.now || 0) / data.miners.max * 100)) : 0).toFixed(1)}%"></div></div>
       </div>
 
       <div class="card">
@@ -457,7 +457,17 @@ function openSettingsModal() {
 
 function closeModal(overlay) {
   overlay.classList.remove("open");
-  overlay.addEventListener("transitionend", () => overlay.remove(), { once: true });
+  // Rely on CSS transition but cap with a 400 ms fallback so the
+  // node is always removed within a predictable window even when
+  // transitions are disabled or skipped.
+  let cleaned = false;
+  const cleanup = () => {
+    if (cleaned) return;
+    cleaned = true;
+    if (overlay.parentNode) overlay.parentNode.removeChild(overlay);
+  };
+  overlay.addEventListener("transitionend", cleanup, { once: true });
+  setTimeout(cleanup, 400);
 }
 
 /* ==========================================================================
@@ -525,13 +535,22 @@ function init() {
    Utility: HTML Escape (XSS prevention)
    ========================================================================== */
 function escapeHtml(str) {
-  if (!str) return "";
+  if (str === null || str === undefined) return "";
+  // Build entity strings by concatenation so the leading '&' and
+  // trailing ';' cannot be silently stripped (see PR code-review fix).
+  // '&' must be replaced first to avoid double-encoding the entities
+  // produced by the remaining rules.
+  const ENT_AMP  = "&" + "amp;";
+  const ENT_LT   = "&" + "lt;";
+  const ENT_GT   = "&" + "gt;";
+  const ENT_QUOT = "&" + "quot;";
+  const ENT_APOS = "&" + "#039;";
   return String(str)
-    .replace(/&/g, "&")
-    .replace(/</g, "<")
-    .replace(/>/g, ">")
-    .replace(/\"/g, "&quot;")
-    .replace(/'/g, "&#039;");
+    .replace(/&/g, ENT_AMP)
+    .replace(/</g, ENT_LT)
+    .replace(/>/g, ENT_GT)
+    .replace(/\"/g, ENT_QUOT)
+    .replace(/'/g, ENT_APOS);
 }
 
 /* ==========================================================================


### PR DESCRIPTION
## 代码审查发现 / Code Review Findings

针对 `main` 分支的独立代码审查,识别并修复以下 5 个问题(覆盖范围 src/main.js, src/api.js)。

### 1. [P0/XSS] `escapeHtml` 对 `<`、`>`、`&` 实为 no-op

**位置**: `src/main.js:527-535`

上一轮 "fix double quotes" (#13) 修复了引号转义,但 `<`、`>`、`&` 三个替换的右值其实是同一字符本身 — 即 `replace(/</g, "<")`。原本应该输出 `<`、`>`、`&` 实体,结果原样输出,导致 `escapeHtml` 对这三个字符完全没有转义作用。

项目反复强调 "XSS 防护、统一 `escapeHtml()`、禁止 `innerHTML` 注入",而该函数却是项目仅有的安全兜底。`renderConnectForm`/`openSettingsModal` 都把 `apiUrl`/`apiToken` 通过 `innerHTML` 写入 DOM(来自 `localStorage`,浏览器 XSS 攻击面虽受限但确实存在)。

**修复**: 用拼接方式构造实体字符串,杜绝任何编辑器/压缩器/转换器悄悄剥离 `&` 与 `;`,并显式说明 `&` 必须最先替换以避免双重编码。

### 2. [P1] 超时不会取消 fetch 连接

**位置**: `src/api.js:17-21, 49-51`

`Promise.race([fetch(...), timeoutPromise(8000)])` 在 8s 后会 reject wrapper,但底层 `fetch` 连接继续在后台跑、消耗资源,且 AbortSignal 缺失使得后续取消操作无能为力。

**修复**: 改用 `AbortController`,在 `finally` 中 `clearTimeout`,让超时真正断开底层连接并清空事件循环里的 timer。

### 3. [P2] Token 长度经由控制台日志泄露

**位置**: `src/api.js:39`

`cfg.apiToken.replace(/./g, "*")` 每位替换为 `*`,控制台里就会输出一个长度等于原 Token 长度的掩码串。任何能扫到浏览器 console 的人都能据此缩小爆破范围(token 长度是低熵信息)。

**修复**: 改用定长字符串 `"**********"`(10 位),不泄露长度。

### 4. [P2] `data.miners.now` 缺失会渲染 `NaN%`

**位置**: `src/main.js:244`

`data.miners.max ? data.miners.now/data.miners.max*100 : 0` — 当 `miners.now` 为 undefined(API 返回异常结构)时,结果是 `NaN`,且这一行使用了与上一行不一致的可选链。

**修复**: 用 `Math.min(100, Math.max(0, …))` 裁剪到 `[0, 100]`,对 `now || 0` 做 null-safe,并补足 `?.max`。

### 5. [P3] `closeModal` 在过渡被禁用时不会清理节点

**位置**: `src/main.js:458-461`

`overlay.addEventListener("transitionend", () => overlay.remove())` 依赖 CSS 过渡结束事件。若用户启用了 `prefers-reduced-motion` 或过渡在其被调用前已完成,overlay 会永久留在 `document.body` 里。

**修复**: 用 `cleaned` flag + 400ms `setTimeout` 兜底,确保 overlay 在可预测时间内一定被移除。

---

### 不打算修改的点(说明理由)

- `getStatusInfo(miners)` 在 `miners===undefined` 时已经返回 `status-offline`(先判 `!miners`),不需要再补。
- `getConfig` 每次重新解析 `localStorage` 性能开销极小,缓存收益不抵复杂度。
- `initChartTooltips` 每次 `renderDashboard` 都重新挂监听器,但 `innerHTML` 会创建全新 DOM 节点,旧节点上不会被再次附加监听,不需要清理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)