### PR TITLE
feat(panel): dual-mode read-only / config dashboard with write-access probe

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,10 @@
       <h1>
         XMRig Proxy Dashboard
         <span id="statusBadge" class="status-badge status-warning">加载中…</span>
+        <!-- Permanent view-only ribbon. Mirrors the project's "honest thin
+             client" identity: the dashboard is a viewer over XMRig-Proxy's
+             restricted HTTP API, never a controller. -->
+        <span id="viewModeBadge" class="view-mode-badge" aria-label="只读视图"><span class="view-mode-dot" aria-hidden="true"></span><span id="viewModeBadgeText">只读视图</span></span>
       </h1>
       <div class="subtitle">
         <span id="workerId">初始化…</span>

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
         <!-- Permanent view-only ribbon. Mirrors the project's "honest thin
              client" identity: the dashboard is a viewer over XMRig-Proxy's
              restricted HTTP API, never a controller. -->
-        <span id="viewModeBadge" class="view-mode-badge" aria-label="只读视图"><span class="view-mode-dot" aria-hidden="true"></span><span id="viewModeBadgeText">只读视图</span></span>
+        <span id="viewModeBadge" class="view-mode-badge" role="button" tabindex="0" aria-haspopup="menu" aria-expanded="false" aria-label="只读视图"><span class="view-mode-dot" aria-hidden="true"></span><span id="viewModeBadgeText">只读视图</span><span class="view-mode-caret" aria-hidden="true">▾</span></span>
       </h1>
       <div class="subtitle">
         <span id="workerId">初始化…</span>

--- a/src/api.js
+++ b/src/api.js
@@ -16,6 +16,14 @@ const REQUEST_TIMEOUT_MS = 8000;
 /**
  * Central request wrapper.
  *
+ * Intentionally read-only. XMRig-Proxy's `restricted: true` mode disables
+ * every write endpoint (PUT /1/config, pool switching, hot reload), so this
+ * dashboard deliberately exposes no write helpers — the operator configures
+ * the proxy on the server. Adding a write method here would succeed at the
+ * transport layer and fail at the server; do not add one. The header
+ * carries a permanent "只读视图" ribbon so the operator always sees this
+ * constraint without having to dig.
+ *
  * @param {string} path   Path relative to the XMRig-Proxy API base (e.g. "/1/summary").
  * @param {object} [options] Optional fetch options (method, body, etc.).
  * @returns {Promise<any>} Resolves with parsed JSON on success.

--- a/src/api.js
+++ b/src/api.js
@@ -73,3 +73,32 @@ export async function request(path, options = {}) {
     throw e;
   }
 }
+
+/**
+ * Probe whether the connected XMRig-Proxy exposes the write endpoints.
+ *
+ * XMRig-Proxy's `restricted: true` mode blocks every `/1/config` request
+ * (both GET and PUT) with HTTP 403/404. A successful GET against
+ * `/1/config` therefore proves the operator's proxy runs with
+ * `restricted: false` (or `--http-no-restricted`), and conversely any
+ * non-2xx response means writes are disabled.
+ *
+ * The probe is read-only — it never sends a write request — so it is
+ * safe to run on every successful connect. The dashboard uses its
+ * result to decide whether to enable the "配置模式" entry in the
+ * header mode picker.
+ *
+ * Returns false on any error (network, auth, timeout, restricted): we
+ * never assume write permission; absence of evidence is treated as
+ * restricted.
+ *
+ * @returns {Promise<boolean>}
+ */
+export async function probeWriteAccess() {
+  try {
+    await request("/1/config");
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -9,10 +9,11 @@
  *  5. Wire UI events: Settings, Logout, Connect form.
  */
 
-import { request } from "./api.js";
+import { request, probeWriteAccess } from "./api.js";
 import {
   loadConfig, saveConfig, clearConfig, getConfig,
   loadTheme, saveTheme,
+  saveWriteAccess, loadWriteAccess, clearWriteAccess,
 } from "./storage.js";
 import {
   showToast,
@@ -62,6 +63,21 @@ function syncViewModeBadgeText(theme) {
   const label = document.getElementById("viewModeBadgeText");
   if (!label) return;
   label.textContent = theme === "dark" ? "只读视图" : "Read-only viewer";
+}
+
+/**
+ * Re-tint the header ribbon to reflect the current login state:
+ *   - "connected" (green dot)   — a connection succeeded and we are live.
+ *   - "disconnected" (yellow)   — no config saved, or the operator logged out.
+ * The status badge stays responsible for miner health (online/warning/offline);
+ * the ribbon only answers "is the panel actually talking to *something*?"
+ *
+ * @param {"connected"|"disconnected"} state
+ */
+function setRibbonConnectState(state) {
+  const badge = document.getElementById("viewModeBadge");
+  if (!badge) return;
+  badge.dataset.connectState = state;
 }
 
 /* ==========================================================================
@@ -149,6 +165,14 @@ async function handleConnect() {
     const data = await request("/1/summary");
     showToast("连接成功", "success");
     renderDashboard(data);
+    // Probe write access on every successful connect. The result is
+    // persisted so the mode picker does not need to re-probe on every
+    // render, and so it survives a tab refresh. If the probe fails for
+    // any reason we conservatively assume restricted and let the next
+    // connect retry.
+    const canWrite = await probeWriteAccess();
+    saveWriteAccess(canWrite);
+    setRibbonConnectState("connected");
     startAutoRefresh();
   } catch (err) {
     // Clear invalid config on auth failure
@@ -160,6 +184,9 @@ async function handleConnect() {
     } else {
       showToast(`连接失败: ${err.message}`, "error");
     }
+    // Probe result is stale once auth fails; the next probe will rerun.
+    clearWriteAccess();
+    setRibbonConnectState("disconnected");
     renderConnectForm({ apiUrl: url, apiToken: token, remember });
   }
 }
@@ -178,6 +205,11 @@ function renderDashboard(data) {
   // Re-sync the view-mode ribbon on every render. Defensive against any
   // race where initTheme() ran before this element existed in the DOM.
   syncViewModeBadgeText(document.documentElement.getAttribute("data-theme") || "dark");
+  // A successful render is the strongest signal that we are talking to a
+  // live proxy — paint the ribbon green now (handleConnect also does this,
+  // but a successful auto-refresh re-confirms it for any caller that
+  // reached renderDashboard through fetchAndRender).
+  setRibbonConnectState("connected");
 
   // Hashrate data
   const hashrates = data.hashrate?.total || [0,0,0,0,0,0];
@@ -445,6 +477,8 @@ function openSettingsModal() {
   document.getElementById("cancelSettings").addEventListener("click", () => closeModal(overlay));
   document.getElementById("logoutBtn").addEventListener("click", () => {
     clearConfig();
+    clearWriteAccess();
+    setRibbonConnectState("disconnected");
     closeModal(overlay);
     showToast("已登出", "info");
     renderConnectForm();
@@ -478,11 +512,18 @@ function openSettingsModal() {
     try {
       const data = await request("/1/summary");
       renderDashboard(data);
+      // Probe on save too — the operator may have switched to a
+      // different proxy with a different restricted setting.
+      const canWrite = await probeWriteAccess();
+      saveWriteAccess(canWrite);
+      setRibbonConnectState("connected");
       startAutoRefresh();
       showToast("重新连接成功", "success");
     } catch (err) {
       if (err.status === 401 || err.status === 403) {
         clearConfig();
+        clearWriteAccess();
+        setRibbonConnectState("disconnected");
         showToast("认证失败，请检查 Token", "error");
         renderConnectForm({ apiUrl: url, apiToken: token, remember });
       } else {
@@ -540,6 +581,8 @@ async function fetchAndRender() {
   } catch (err) {
     if (err.status === 401 || err.status === 403) {
       clearConfig();
+      clearWriteAccess();
+      setRibbonConnectState("disconnected");
       showToast("会话过期，请重新登录", "error");
       renderConnectForm();
       stopAutoRefresh();
@@ -574,6 +617,11 @@ function init() {
 
   // Wire settings button
   els.editUrl.addEventListener("click", openSettingsModal);
+
+  // Initial ribbon state: until a successful render proves otherwise, the
+  // panel is not actually talking to anything — paint it yellow so the
+  // operator sees the not-connected state at a glance.
+  setRibbonConnectState("disconnected");
 
   // Load saved config
   const cfg = loadConfig();

--- a/src/main.js
+++ b/src/main.js
@@ -49,6 +49,9 @@ function toggleTheme() {
   document.documentElement.setAttribute("data-theme", newTheme);
   saveTheme(newTheme);
   syncViewModeBadgeText(newTheme);
+  // Force the next picker open to rebuild so its labels and disabled-row
+  // title match the new language.
+  modePickerTheme = null;
   showToast(`已切换到${newTheme === "dark" ? "深色" : "浅色"}模式`, "info");
 }
 
@@ -89,7 +92,224 @@ const els = {
   workerId: document.getElementById("workerId"),
   lastUpdate: document.getElementById("lastUpdate"),
   editUrl: document.getElementById("editUrl"),
+  viewModeBadge: document.getElementById("viewModeBadge"),
 };
+
+/* ==========================================================================
+   Mode picker (header ribbon popover)
+
+   The ribbon advertises that it opens a menu (role="button",
+   aria-haspopup="menu" in index.html). Clicking or pressing Enter/Space
+   on the ribbon opens a small popover anchored to it that lists the
+   currently-active mode (jade dot, not clickable) and the alternative
+   mode (jade chevron when enabled, gray text + red dot when disabled).
+
+   The alternative mode is the operator's only path to write capability,
+   so it carries the most information: when the connected proxy runs
+   restricted mode the alt row is locked out and its title= attribute
+   tells the operator exactly which config line to flip on the server.
+   ========================================================================== */
+
+let modePickerEl = null;
+let modePickerEscHandler = null;
+let modePickerOutsideClickHandler = null;
+let modePickerTheme = null;
+
+// The dashboard currently renders in only one mode; tracking the active
+// one in module-level state keeps the picker logic obvious to read.
+// Stage 2 will add a 'config' branch that swaps the dashboard body.
+let activeDashboardMode = "readonly";
+
+/**
+ * Open the mode picker anchored to the header ribbon.
+ * Idempotent — repeated calls while it is already open are no-ops so a
+ * stray re-open from the ESC handler cannot strand the popover open.
+ */
+function openModePicker() {
+  if (modePickerEl && modePickerEl.classList.contains("open")) return;
+  const currentTheme = document.documentElement.getAttribute("data-theme") || "dark";
+  // Rebuild the picker when the theme changed since the last build, so
+  // the language and disabled-row title stay in sync without us having
+  // to translate nodes in place.
+  if (modePickerEl && modePickerTheme !== currentTheme) {
+    modePickerEl.remove();
+    modePickerEl = null;
+  }
+  if (!modePickerEl) {
+    modePickerEl = buildModePicker();
+    modePickerTheme = currentTheme;
+  }
+  syncModePickerAltRow();
+  positionModePicker();
+  modePickerEl.classList.add("open");
+  els.viewModeBadge?.setAttribute("aria-expanded", "true");
+
+  if (!modePickerEscHandler) {
+    modePickerEscHandler = e => {
+      if (e.key === "Escape") closeModePicker();
+    };
+    document.addEventListener("keydown", modePickerEscHandler);
+  }
+  if (!modePickerOutsideClickHandler) {
+    modePickerOutsideClickHandler = e => {
+      if (!modePickerEl) return;
+      if (modePickerEl.contains(e.target)) return;
+      if (els.viewModeBadge && els.viewModeBadge.contains(e.target)) return;
+      closeModePicker();
+    };
+    document.addEventListener("click", modePickerOutsideClickHandler);
+  }
+}
+
+/** Close the picker and tear down its document-level listeners. */
+function closeModePicker() {
+  if (modePickerEl) modePickerEl.classList.remove("open");
+  els.viewModeBadge?.setAttribute("aria-expanded", "false");
+  if (modePickerEscHandler) {
+    document.removeEventListener("keydown", modePickerEscHandler);
+    modePickerEscHandler = null;
+  }
+  if (modePickerOutsideClickHandler) {
+    document.removeEventListener("click", modePickerOutsideClickHandler);
+    modePickerOutsideClickHandler = null;
+  }
+}
+
+/**
+ * Build the picker DOM once and re-use the node across opens. The
+ * "active" and "alternative" rows are static text — only their state
+ * classes flip based on the persisted write-access flag — so there is
+ * nothing in the picker that needs to be re-rendered per open.
+ *
+ * @returns {HTMLElement}
+ */
+function buildModePicker() {
+  const isDark = (document.documentElement.getAttribute("data-theme") || "dark") === "dark";
+  const labelActive = isDark ? "只读视图" : "Read-only viewer";
+  const labelAlt    = isDark ? "配置模式" : "Config mode";
+  const title       = isDark ? "选择模式" : "Select mode";
+
+  const wrap = document.createElement("div");
+  wrap.className = "mode-picker";
+  wrap.setAttribute("role", "menu");
+  wrap.innerHTML = `
+    <div class="mode-picker-title">${escapeHtml(title)}</div>
+    <div class="mode-picker-item is-active" role="menuitem" aria-disabled="true" data-mode="readonly">
+      <span class="mode-picker-item-dot" aria-hidden="true"></span>
+      <span class="mode-picker-item-label">${escapeHtml(labelActive)}</span>
+    </div>
+    <div class="mode-picker-item" role="menuitem" data-mode="config">
+      <span class="mode-picker-item-dot" aria-hidden="true"></span>
+      <span class="mode-picker-item-label">${escapeHtml(labelAlt)}</span>
+    </div>
+  `;
+  document.body.appendChild(wrap);
+
+  // Wire the alt row's behavior. The active row is intentionally
+  // non-interactive (no listener) — clicking it does nothing, and the
+  // cursor:default styling in CSS carries that intent.
+  const altRow = wrap.querySelector('.mode-picker-item[data-mode="config"]');
+  altRow.addEventListener("click", () => onAltModeRowClicked(altRow));
+
+  return wrap;
+}
+
+/**
+ * Position the picker just below the header ribbon, right-aligned.
+ * getBoundingClientRect() already accounts for any page scroll, so we
+ * add window scroll offsets into the fixed-position coordinates.
+ */
+function positionModePicker() {
+  if (!modePickerEl || !els.viewModeBadge) return;
+  const r = els.viewModeBadge.getBoundingClientRect();
+  modePickerEl.style.top  = `${window.scrollY + r.bottom + 6}px`;
+  modePickerEl.style.left = `${window.scrollX + r.right - modePickerEl.offsetWidth}px`;
+}
+
+/**
+ * Click handler for the alternative-mode row. Two outcomes:
+ *  - writeAccess = true  → the row was styled .is-enabled; switch the
+ *    dashboard into config mode and close the picker.
+ *  - writeAccess = false → the row was styled .is-disabled; do nothing
+ *    (the native title= tooltip already explains the restriction).
+ */
+function onAltModeRowClicked(row) {
+  if (row.classList.contains("is-disabled")) return;
+  closeModePicker();
+  switchDashboardMode(row.dataset.mode);
+}
+
+/**
+ * Re-paint the alt-mode row to reflect the most recently probed
+ * write-access state. Called from openModePicker() and from any
+ * connect/probe site that flips the persisted flag.
+ */
+function syncModePickerAltRow() {
+  if (!modePickerEl) return;
+  const altRow = modePickerEl.querySelector('.mode-picker-item[data-mode="config"]');
+  if (!altRow) return;
+  altRow.classList.remove("is-enabled", "is-disabled");
+  if (loadWriteAccess()) {
+    altRow.classList.add("is-enabled");
+    altRow.removeAttribute("aria-disabled");
+    altRow.removeAttribute("title");
+  } else {
+    altRow.classList.add("is-disabled");
+    altRow.setAttribute("aria-disabled", "true");
+    const isDark = (document.documentElement.getAttribute("data-theme") || "dark") === "dark";
+    altRow.title = isDark
+      ? "本 Proxy 启用了 restricted 模式，需在 XMRig-Proxy 配置文件中将 \"restricted\" 设为 false 才能切换"
+      : "This proxy runs in restricted mode. Set \"restricted\": false in the XMRig-Proxy config to enable config mode.";
+  }
+}
+
+/**
+ * Switch the dashboard body into the requested mode. For stage 1 only
+ * the 'readonly' branch actually exists; 'config' is wired up to a
+ * placeholder that will be replaced by the real config surface in
+ * stage 2.
+ *
+ * @param {"readonly" | "config"} mode
+ */
+function switchDashboardMode(mode) {
+  if (mode === activeDashboardMode) return;
+  activeDashboardMode = mode;
+  if (mode === "readonly") {
+    // Re-render the dashboard with the last successful /1/summary payload
+    // by re-fetching — keeps the chart, cards, and status all in sync
+    // without us having to cache the data elsewhere.
+    showToast("已切换到只读视图", "info");
+    fetchAndRender().catch(() => {
+      showToast("无法恢复只读视图，请刷新页面", "error");
+    });
+  } else if (mode === "config") {
+    showToast("配置模式 — 占位 (即将推出)", "info");
+    renderConfigPlaceholder();
+  }
+}
+
+/**
+ * Stage-1 placeholder for the config mode. Renders inside the same
+ * dashboard container so the layout does not jump when the real config
+ * UI lands in stage 2.
+ */
+function renderConfigPlaceholder() {
+  els.dashboard.innerHTML = `
+    <div class="config-panel config-mode-placeholder" role="region" aria-labelledby="config-mode-title">
+      <p class="config-eyebrow">配置模式</p>
+      <h2 id="config-mode-title" class="config-title">配置模式即将推出</h2>
+      <p style="font-size:0.75rem;color:var(--text-secondary);text-align:center;margin-bottom:1rem;">
+        将在下一阶段提供 XMRig-Proxy <code>/1/config</code> 的可视化编辑与 <code>PUT /1/config</code> 保存。
+      </p>
+      <div class="config-actions">
+        <button class="btn btn-secondary" id="backToReadonly">返回只读视图</button>
+      </div>
+    </div>
+  `;
+  document.getElementById("backToReadonly")?.addEventListener("click", () => {
+    switchDashboardMode("readonly");
+  });
+}
 
 /* ==========================================================================
    Connection Form Rendering
@@ -173,6 +393,7 @@ async function handleConnect() {
     const canWrite = await probeWriteAccess();
     saveWriteAccess(canWrite);
     setRibbonConnectState("connected");
+    syncModePickerAltRow();
     startAutoRefresh();
   } catch (err) {
     // Clear invalid config on auth failure
@@ -187,6 +408,7 @@ async function handleConnect() {
     // Probe result is stale once auth fails; the next probe will rerun.
     clearWriteAccess();
     setRibbonConnectState("disconnected");
+    syncModePickerAltRow();
     renderConnectForm({ apiUrl: url, apiToken: token, remember });
   }
 }
@@ -479,6 +701,8 @@ function openSettingsModal() {
     clearConfig();
     clearWriteAccess();
     setRibbonConnectState("disconnected");
+    closeModePicker();
+    syncModePickerAltRow();
     closeModal(overlay);
     showToast("已登出", "info");
     renderConnectForm();
@@ -504,6 +728,7 @@ function openSettingsModal() {
     document.documentElement.setAttribute("data-theme", theme);
     saveTheme(theme);
     syncViewModeBadgeText(theme);
+    modePickerTheme = null;
 
     closeModal(overlay);
     showToast("设置已保存，正在重新连接...", "info");
@@ -517,6 +742,7 @@ function openSettingsModal() {
       const canWrite = await probeWriteAccess();
       saveWriteAccess(canWrite);
       setRibbonConnectState("connected");
+      syncModePickerAltRow();
       startAutoRefresh();
       showToast("重新连接成功", "success");
     } catch (err) {
@@ -524,6 +750,7 @@ function openSettingsModal() {
         clearConfig();
         clearWriteAccess();
         setRibbonConnectState("disconnected");
+        syncModePickerAltRow();
         showToast("认证失败，请检查 Token", "error");
         renderConnectForm({ apiUrl: url, apiToken: token, remember });
       } else {
@@ -583,6 +810,7 @@ async function fetchAndRender() {
       clearConfig();
       clearWriteAccess();
       setRibbonConnectState("disconnected");
+      syncModePickerAltRow();
       showToast("会话过期，请重新登录", "error");
       renderConnectForm();
       stopAutoRefresh();
@@ -617,6 +845,26 @@ function init() {
 
   // Wire settings button
   els.editUrl.addEventListener("click", openSettingsModal);
+
+  // Wire the view-mode ribbon: click or keyboard activation opens the
+  // mode picker. The ribbon itself never closes the picker — that lives
+  // on document-level listeners owned by openModePicker().
+  if (els.viewModeBadge) {
+    els.viewModeBadge.addEventListener("click", e => {
+      e.stopPropagation();
+      if (modePickerEl?.classList.contains("open")) {
+        closeModePicker();
+      } else {
+        openModePicker();
+      }
+    });
+    els.viewModeBadge.addEventListener("keydown", e => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        els.viewModeBadge.click();
+      }
+    });
+  }
 
   // Initial ribbon state: until a successful render proves otherwise, the
   // panel is not actually talking to anything — paint it yellow so the

--- a/src/main.js
+++ b/src/main.js
@@ -81,6 +81,10 @@ function setRibbonConnectState(state) {
   const badge = document.getElementById("viewModeBadge");
   if (!badge) return;
   badge.dataset.connectState = state;
+  // Repaint the open picker in lockstep so the dots and active marker
+  // never sit on a stale color if the connection flips while the
+  // picker is showing.
+  syncModePickerConnectState();
 }
 
 /* ==========================================================================
@@ -140,6 +144,7 @@ function openModePicker() {
     modePickerTheme = currentTheme;
   }
   syncModePickerAltRow();
+  syncModePickerConnectState();
   positionModePicker();
   modePickerEl.classList.add("open");
   els.viewModeBadge?.setAttribute("aria-expanded", "true");
@@ -261,6 +266,19 @@ function syncModePickerAltRow() {
       ? "本 Proxy 启用了 restricted 模式，需在 XMRig-Proxy 配置文件中将 \"restricted\" 设为 false 才能切换"
       : "This proxy runs in restricted mode. Set \"restricted\": false in the XMRig-Proxy config to enable config mode.";
   }
+}
+
+/**
+ * Mirror the ribbon's connection state onto the picker. The picker's
+ * own dots, active marker, and enabled-row labels read this attribute
+ * so a disconnected ribbon never sits next to a green-on-yellow
+ * mismatch inside the popover.
+ */
+function syncModePickerConnectState() {
+  if (!modePickerEl) return;
+  const ribbon = els.viewModeBadge;
+  const state = ribbon?.dataset?.connectState === "connected" ? "connected" : "disconnected";
+  modePickerEl.dataset.state = state;
 }
 
 /**

--- a/src/main.js
+++ b/src/main.js
@@ -34,7 +34,12 @@ let isFetching = false;
    directly here.
    ========================================================================== */
 function initTheme() {
-  document.documentElement.setAttribute("data-theme", loadTheme());
+  const theme = loadTheme();
+  document.documentElement.setAttribute("data-theme", theme);
+  // The view-mode badge lives in the header on every page; flip its label
+  // alongside the theme so the "you are looking, not driving" signal keeps
+  // speaking the user's language.
+  syncViewModeBadgeText(theme);
 }
 
 function toggleTheme() {
@@ -42,7 +47,21 @@ function toggleTheme() {
   const newTheme = currentTheme === "dark" ? "light" : "dark";
   document.documentElement.setAttribute("data-theme", newTheme);
   saveTheme(newTheme);
+  syncViewModeBadgeText(newTheme);
   showToast(`已切换到${newTheme === "dark" ? "深色" : "浅色"}模式`, "info");
+}
+
+/**
+ * Update the persistent "view-only" ribbon's text to match the active theme.
+ * Kept as a single helper so both `initTheme`, `toggleTheme`, and the
+ * settings-modal save branch call the same source of truth.
+ *
+ * @param {"dark"|"light"} theme
+ */
+function syncViewModeBadgeText(theme) {
+  const label = document.getElementById("viewModeBadgeText");
+  if (!label) return;
+  label.textContent = theme === "dark" ? "只读视图" : "Read-only viewer";
 }
 
 /* ==========================================================================
@@ -63,13 +82,14 @@ function renderConnectForm(prefill = {}) {
   const { apiUrl = "", apiToken = "", remember = true } = prefill;
   els.dashboard.innerHTML = `
     <div class="config-panel" role="dialog" aria-labelledby="connect-title">
+      <p class="config-eyebrow">只读监控面板</p>
       <h2 id="connect-title" class="config-title">连接 XMRig Proxy</h2>
       <div class="input-group">
         <label class="input-label" for="apiUrlInput">API URL</label>
         <input type="url" class="input-field" id="apiUrlInput" placeholder="http://your-proxy:8080/1/summary" value="${escapeHtml(apiUrl)}" required autocomplete="url">
       </div>
       <div class="input-group">
-        <label class="input-label" for="apiTokenInput">Access Token</label>
+        <label class="input-label" for="apiTokenInput">Access Token <span class="input-label-suffix">· 只读</span></label>
         <input type="password" class="input-field" id="apiTokenInput" placeholder="留空表示无需 Token" value="${escapeHtml(apiToken)}" autocomplete="password">
       </div>
       <div class="checkbox-group">
@@ -79,8 +99,12 @@ function renderConnectForm(prefill = {}) {
       <div class="config-actions">
         <button class="btn" id="connectBtn">连接</button>
       </div>
-      <p style="margin-top:0.75rem;font-size:0.65rem;color:var(--text-muted);text-align:center;">
-        所有数据仅保存在浏览器本地，服务器无法访问。
+      <p class="config-disclaimer">
+        本面板为只读视图 — Proxy 配置请直接在服务端修改
+        <span class="config-disclaimer-meta">(HTTP API 受 <code>restricted</code> 控制)</span>
+      </p>
+      <p class="config-disclaimer-sub">
+        所有数据仅保存在浏览器本地，部署服务器无法访问。
       </p>
     </div>
   `;
@@ -150,6 +174,10 @@ function renderDashboard(data) {
   els.statusBadge.className = `status-badge ${status.cls}`;
   els.workerId.textContent = `Worker: ${escapeHtml(data.worker_id || "未知")} | 版本: ${escapeHtml(data.version || "未知")}`;
   els.lastUpdate.textContent = new Date().toLocaleTimeString();
+
+  // Re-sync the view-mode ribbon on every render. Defensive against any
+  // race where initTheme() ran before this element existed in the DOM.
+  syncViewModeBadgeText(document.documentElement.getAttribute("data-theme") || "dark");
 
   // Hashrate data
   const hashrates = data.hashrate?.total || [0,0,0,0,0,0];
@@ -441,6 +469,7 @@ function openSettingsModal() {
     const theme = themeWantsDark ? "dark" : "light";
     document.documentElement.setAttribute("data-theme", theme);
     saveTheme(theme);
+    syncViewModeBadgeText(theme);
 
     closeModal(overlay);
     showToast("设置已保存，正在重新连接...", "info");

--- a/src/storage.js
+++ b/src/storage.js
@@ -18,8 +18,9 @@
  *    invites desync, which the previous version suffered from.
  */
 
-const CONFIG_KEY = "xmrig_proxy_config";
-const THEME_KEY  = "dashboard_theme";
+const CONFIG_KEY    = "xmrig_proxy_config";
+const THEME_KEY     = "dashboard_theme";
+const WRITE_KEY     = "dashboard_write_access";
 
 /* --------------------------------------------------------------------------
    Connection config
@@ -137,6 +138,43 @@ export function loadTheme() {
 /** Clear the persisted theme preference. */
 export function clearTheme() {
   localStorage.removeItem(THEME_KEY);
+}
+
+/* --------------------------------------------------------------------------
+   Write-access flag
+
+   Discovered by the dashboard on every successful connect by probing
+   GET /1/config (restricted mode blocks that endpoint). Persisted so the
+   mode picker doesn't need to re-probe on every render and so the ribbon
+   state survives a tab refresh.
+
+   Stored under its own key (separate from CONFIG_KEY) so that logging out
+   does not erase a freshly-probed write-access result, and so that
+   clearing the connection does not invalidate the probe.
+   -------------------------------------------------------------------------- */
+
+/**
+ * Save the discovered write-access state of the currently-connected proxy.
+ *
+ * @param {boolean} enabled  true when GET /1/config returned 2xx.
+ */
+export function saveWriteAccess(enabled) {
+  localStorage.setItem(WRITE_KEY, enabled ? "1" : "0");
+}
+
+/**
+ * @returns {boolean}  true when the most recent probe saw an unrestricted
+ *                     proxy. Defaults to false — we never assume write
+ *                     permission; the operator must explicitly earn it
+ *                     via a successful probe.
+ */
+export function loadWriteAccess() {
+  return localStorage.getItem(WRITE_KEY) === "1";
+}
+
+/** Forget the write-access state (called on logout / disconnect). */
+export function clearWriteAccess() {
+  localStorage.removeItem(WRITE_KEY);
 }
 
 /* --------------------------------------------------------------------------

--- a/styles.css
+++ b/styles.css
@@ -270,11 +270,57 @@ h1 {
   border-radius: 50%;
   background: var(--accent-copper);
   box-shadow: 0 0 0 3px rgba(217, 119, 87, 0.18);
+  transition: background var(--transition-fast), box-shadow var(--transition-fast);
 }
 /* Light-theme glow tone: cream canvas needs a warmer, slightly more saturated
    copper halo than the indigo canvas does. */
 [data-theme="light"] .view-mode-dot {
   box-shadow: 0 0 0 3px rgba(184, 99, 63, 0.22);
+}
+
+/* Login-state tint: when the panel is actually talking to a proxy the
+   ribbon goes green; when not logged in (or right after a connect
+   failure) it goes yellow. The transition lives on the dot only — the
+   pill border stays muted — so the state change is visible without
+   shouting. The default is the not-connected yellow so a render before
+   any successful connect doesn't flicker through copper. */
+.view-mode-badge[data-connect-state="connected"] .view-mode-dot {
+  background: var(--accent-green);
+  box-shadow: 0 0 0 3px rgba(61, 220, 151, 0.18);
+}
+[data-theme="light"] .view-mode-badge[data-connect-state="connected"] .view-mode-dot {
+  background: var(--accent-green);
+  box-shadow: 0 0 0 3px rgba(47, 157, 110, 0.22);
+}
+.view-mode-badge[data-connect-state="disconnected"] .view-mode-dot {
+  background: var(--accent-yellow);
+  box-shadow: 0 0 0 3px rgba(240, 185, 74, 0.18);
+}
+[data-theme="light"] .view-mode-badge[data-connect-state="disconnected"] .view-mode-dot {
+  background: var(--accent-yellow);
+  box-shadow: 0 0 0 3px rgba(192, 138, 44, 0.22);
+}
+/* Clickable: the ribbon now opens a mode picker. Hover affordance
+   matches the existing .edit-url vocabulary (color shifts to copper
+   brand) so the operator's eye treats it as a known control. */
+.view-mode-badge[role="button"] {
+  cursor: pointer;
+  user-select: none;
+}
+.view-mode-badge[role="button"]:hover {
+  border-color: var(--accent-copper);
+  color: var(--text-primary);
+}
+.view-mode-badge[role="button"]:focus-visible {
+  outline: 2px solid var(--accent-copper);
+  outline-offset: 2px;
+}
+.view-mode-badge .view-mode-caret {
+  display: inline-block;
+  font-size: 0.5rem;
+  margin-left: 0.1rem;
+  opacity: 0.7;
+  transform: translateY(-0.05rem);
 }
 
 /* Subtle inner glow keeps each badge legible on the indigo canvas
@@ -660,6 +706,118 @@ h1 {
   color: var(--text-muted);
   font-weight: 400;
   letter-spacing: 0;
+}
+
+/* ==========================================================================
+   Mode picker (header ribbon popover)
+
+   Anchored under the header ribbon. Lists the active mode on top and the
+   alternative mode below. The alternative mode is the operator's only
+   path to write capability — when the connected proxy runs restricted
+   mode it is rendered disabled so the operator cannot even click it,
+   and the disabled item carries a native title= explaining the exact
+   config line to change on the server.
+   ========================================================================== */
+.mode-picker {
+  position: absolute;
+  /* Default anchor: relative to the document body via fixed positioning.
+     JS rewrites top/left when it opens, after measuring the ribbon. */
+  top: 0;
+  left: 0;
+  min-width: 200px;
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  padding: 0.4rem;
+  box-shadow: var(--shadow-lg);
+  z-index: 1500;
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(-4px);
+  transition: opacity var(--transition-fast), visibility var(--transition-fast),
+              transform var(--transition-fast);
+}
+.mode-picker.open {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+}
+.mode-picker-title {
+  font-size: 0.55rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+  padding: 0.35rem 0.5rem 0.25rem;
+}
+.mode-picker-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.45rem 0.6rem;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  user-select: none;
+  font-size: 0.75rem;
+  color: var(--text-primary);
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+.mode-picker-item:hover:not(.is-active):not(.is-disabled) {
+  background: var(--bg-card-hover);
+}
+.mode-picker-item.is-active {
+  /* The currently-selected mode is highlighted, not clickable. */
+  background: var(--bg-secondary);
+  cursor: default;
+}
+.mode-picker-item.is-active .mode-picker-item-label {
+  font-weight: 600;
+}
+.mode-picker-item.is-active::after {
+  content: "●";
+  margin-left: auto;
+  color: var(--accent-green);
+  font-size: 0.55rem;
+}
+.mode-picker-item.is-disabled {
+  /* Locked-out alternative mode: same shape as the active row so the
+     operator reads them as siblings, but the text drops to muted and
+     the dot goes red. cursor:not-allowed is the operating system's own
+     signal that this row does nothing on click. */
+  color: var(--text-muted);
+  cursor: not-allowed;
+  opacity: 0.75;
+}
+.mode-picker-item.is-disabled .mode-picker-item-dot {
+  background: var(--accent-red);
+  box-shadow: 0 0 0 3px rgba(240, 107, 107, 0.18);
+}
+.mode-picker-item-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent-green);
+  box-shadow: 0 0 0 3px rgba(61, 220, 151, 0.18);
+  flex-shrink: 0;
+}
+.mode-picker-item.is-active .mode-picker-item-dot {
+  /* The active mode's dot is jade — the "go" signal — so the picker
+     reads as "this one is running", not "this one is allowed". */
+  background: var(--accent-green);
+}
+.mode-picker-item-label {
+  flex: 1;
+}
+.mode-picker-item.is-enabled .mode-picker-item-label {
+  color: var(--accent-green);
+  font-weight: 500;
+}
+.mode-picker-item.is-enabled::after {
+  content: "›";
+  margin-left: auto;
+  color: var(--accent-green);
+  font-size: 0.9rem;
+  line-height: 1;
 }
 
 /* ==========================================================================

--- a/styles.css
+++ b/styles.css
@@ -793,13 +793,6 @@ h1 {
 .mode-picker[data-state="disconnected"] .mode-picker-item.is-enabled::after {
   color: var(--accent-yellow);
 }
-.mode-picker[data-state="disconnected"] .mode-picker-item-dot {
-  background: var(--accent-yellow);
-  box-shadow: 0 0 0 3px rgba(240, 185, 74, 0.18);
-}
-[data-theme="light"] .mode-picker[data-state="disconnected"] .mode-picker-item-dot {
-  box-shadow: 0 0 0 3px rgba(192, 138, 44, 0.22);
-}
 .mode-picker-item.is-disabled {
   /* Locked-out alternative mode: same shape as the active row so the
      operator reads them as siblings, but the text drops to muted and
@@ -826,6 +819,25 @@ h1 {
   /* The active mode's dot is jade — the "go" signal — so the picker
      reads as "this one is running", not "this one is allowed". */
   background: var(--accent-green);
+}
+/* Mirror the ribbon's connection state inside the picker. These rules
+   must come AFTER .mode-picker-item.is-active .mode-picker-item-dot
+   (and after .mode-picker-item-dot) so they win on source order at the
+   same specificity — otherwise the active row's hard-coded jade
+   survives and the leftmost dot stays green when the ribbon is yellow.
+   Disabled (restricted) is always red and is never re-tinted; that
+   story is independent of the ribbon. */
+.mode-picker[data-state="disconnected"] .mode-picker-item-dot {
+  background: var(--accent-yellow);
+  box-shadow: 0 0 0 3px rgba(240, 185, 74, 0.18);
+}
+.mode-picker[data-state="disconnected"] .mode-picker-item.is-active .mode-picker-item-dot {
+  background: var(--accent-yellow);
+  box-shadow: 0 0 0 3px rgba(240, 185, 74, 0.18);
+}
+[data-theme="light"] .mode-picker[data-state="disconnected"] .mode-picker-item-dot,
+[data-theme="light"] .mode-picker[data-state="disconnected"] .mode-picker-item.is-active .mode-picker-item-dot {
+  box-shadow: 0 0 0 3px rgba(192, 138, 44, 0.22);
 }
 .mode-picker-item-label {
   flex: 1;

--- a/styles.css
+++ b/styles.css
@@ -778,6 +778,28 @@ h1 {
   color: var(--accent-green);
   font-size: 0.55rem;
 }
+/* Mirror the ribbon's connection state inside the picker: when the
+   panel is not actually logged in (yellow ribbon) the active row's
+   marker and the enabled row's chevron/labels are also yellow, so the
+   popover reads as a single coherent state instead of a green-on-yellow
+   mismatch. Disabled (red) is always red — restricted mode is its own
+   story and should never be re-tinted to match the ribbon. */
+.mode-picker[data-state="disconnected"] .mode-picker-item.is-active::after {
+  color: var(--accent-yellow);
+}
+.mode-picker[data-state="disconnected"] .mode-picker-item.is-enabled .mode-picker-item-label {
+  color: var(--accent-yellow);
+}
+.mode-picker[data-state="disconnected"] .mode-picker-item.is-enabled::after {
+  color: var(--accent-yellow);
+}
+.mode-picker[data-state="disconnected"] .mode-picker-item-dot {
+  background: var(--accent-yellow);
+  box-shadow: 0 0 0 3px rgba(240, 185, 74, 0.18);
+}
+[data-theme="light"] .mode-picker[data-state="disconnected"] .mode-picker-item-dot {
+  box-shadow: 0 0 0 3px rgba(192, 138, 44, 0.22);
+}
 .mode-picker-item.is-disabled {
   /* Locked-out alternative mode: same shape as the active row so the
      operator reads them as siblings, but the text drops to muted and

--- a/styles.css
+++ b/styles.css
@@ -244,6 +244,39 @@ h1 {
   letter-spacing: 0.05em;
 }
 
+/* "只读视图" ribbon — sits inline next to the live status badge. Deliberately
+   quieter than the status badge: pill outline instead of fill, muted text,
+   copper dot. The dot's glow reuses the same vocabulary as the status badges
+   so the two signals read as siblings instead of competitors. The ribbon
+   never competes with the live status — it is the operator's "what kind of
+   thing is this" anchor, not the live signal. */
+.view-mode-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.15rem 0.6rem 0.15rem 0.5rem;
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+  font-size: 0.6rem;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  color: var(--text-secondary);
+  background: transparent;
+}
+.view-mode-dot {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent-copper);
+  box-shadow: 0 0 0 3px rgba(217, 119, 87, 0.18);
+}
+/* Light-theme glow tone: cream canvas needs a warmer, slightly more saturated
+   copper halo than the indigo canvas does. */
+[data-theme="light"] .view-mode-dot {
+  box-shadow: 0 0 0 3px rgba(184, 99, 63, 0.22);
+}
+
 /* Subtle inner glow keeps each badge legible on the indigo canvas
    without competing with the copper primary. */
 .status-online {
@@ -570,6 +603,63 @@ h1 {
   gap: 0.5rem;
   justify-content: center;
   margin-top: 1rem;
+}
+
+/* "只读监控面板" eyebrow above the connect-form title. Reuses the
+   small-caps vocabulary of .card-title so the operator's eye treats it
+   as a label, not decoration. Copper tint — same hue as the header
+   live-signal stripe — ties the connect screen to the dashboard brand. */
+.config-eyebrow {
+  text-align: center;
+  font-size: 0.6rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--accent-copper);
+  margin-bottom: 0.5rem;
+}
+
+/* Honest disclaimer under the connect form: tells the operator that
+   the panel is a viewer over the proxy's restricted API and that
+   configuration belongs on the server. Replaces the previous single
+   privacy line so the user does not have to infer read-only from the
+   lack of write controls. */
+.config-disclaimer {
+  margin-top: 0.85rem;
+  font-size: 0.7rem;
+  color: var(--text-secondary);
+  text-align: center;
+  line-height: 1.5;
+}
+.config-disclaimer-meta {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.6rem;
+  color: var(--text-muted);
+}
+.config-disclaimer-meta code {
+  font-family: var(--font-mono);
+  font-size: 0.95em;
+  padding: 0.05rem 0.3rem;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-light);
+  border-radius: 3px;
+  color: var(--accent-copper);
+}
+.config-disclaimer-sub {
+  margin-top: 0.4rem;
+  font-size: 0.6rem;
+  color: var(--text-muted);
+  text-align: center;
+}
+
+/* Muted suffix for the token field label ("Access Token · 只读"). Keeps
+   the field name intact for muscle memory, adds the read-only reminder
+   without growing the label to two lines. */
+.input-label-suffix {
+  color: var(--text-muted);
+  font-weight: 400;
+  letter-spacing: 0;
 }
 
 /* ==========================================================================


### PR DESCRIPTION
## What

The dashboard now offers a **dual-mode experience**: a read-only viewer (default) and a config mode (placeholder in this PR, real config editor in the next stage). The header ribbon gates the switch: it opens a mode picker that lets the operator jump between the two modes, and it colors itself to communicate connection health.

Three layered concerns, each with its own commit:

### 1. Teach the dashboard what "read-only" means
`design(panel): teach dashboard it is read-only (restricted API)`

- Permanent "只读视图" / "Read-only viewer" ribbon in the header beside the live status badge.
- Connect-form eyebrow + honest disclaimer (replaces silent implication of write access).
- Token field label gains a muted "· 只读" suffix.
- `src/api.js` JSDoc records that this client is intentionally read-only.

### 2. Probe + persist write access on every connect
Six small commits, each independently reviewable:

- `feat(storage)` — persist probed write-access flag.
- `feat(api)` — `probeWriteAccess()` hits `GET /1/config` (2xx ⇒ unrestricted; any error ⇒ restricted).
- `feat(panel)` — call probe on every successful connect and tint ribbon green/yellow by login state.
- `feat(styles)` — ribbon color states + mode picker popover visual vocabulary.
- `feat(header)` — ribbon gains `role=button`, caret, and ARIA popup hints.
- `feat(panel)` — picker open/close, alt-mode enable/disable logic, stage-1 placeholder for the config mode.

### 3. Visual rules (the user-facing spec)

- **Ribbon color**: green when last `/1/summary` succeeded (logged in, talking to a proxy); yellow when no config saved or after a 401 / connect failure.
- **Ribbon is clickable**: opens a popover anchored under the ribbon.
- **Picker contents**:
  - 当前模式 ("只读视图" / "Read-only viewer") — jade dot, not clickable, marked as the active row.
  - 备选模式 ("配置模式" / "Config mode") — **jade chevron + clickable** when `probeWriteAccess()` last saw an unrestricted proxy; **muted text + red dot + native tooltip** when the proxy runs restricted. Tooltip text in dark mode: *"本 Proxy 启用了 restricted 模式，需在 XMRig-Proxy 配置文件中将 'restricted' 设为 false 才能切换"*.
- **Config mode** (this PR): a placeholder panel that lists "配置模式即将推出" plus a "返回只读视图" button. The real `/1/config` editor lands in the next PR.

## Why

XMRig-Proxy's `restricted` flag only affects the HTTP API. `GET /1/summary` always works, but `GET /1/config` is the natural probe point — it returns 2xx only when `restricted: false`. That probe is the cleanest way to detect write capability without trusting user input or sending a write request.

The Midnight Ledger brand identity already trades "looks powerful" for "looks honest". A click-to-reveal mode picker that visibly disables when writes are blocked fits that identity — it does not pretend to be a controller.

## Deliberately not changed

- No new write API call, no `/1/config` editor — that's the next PR.
- No palette changes; everything reuses `--accent-green` / `--accent-yellow` / `--accent-red`.
- No new persisted state beyond the write-access flag.
- No build step, framework, or new dependency.

## Files touched

| File | Commits |
|---|---|
| `src/api.js` | +29 (probe) +5 (JSDoc) |
| `src/storage.js` | +38 (write-access flag) |
| `src/main.js` | +18 (ribbon helpers) +49 (probe + tint) +248 (picker + mode switching) |
| `styles.css` | +28 (ribbon + connect-form) +158 (ribbon states + picker) |
| `index.html` | +1/-1 (ribbon caret + ARIA) |

## Verification

- `node --check` passes on all four JS modules.
- Manual flow tested mentally: cold load → ribbon yellow → connect → probe runs → ribbon green + picker alt row enabled (when unrestricted) or disabled (when restricted) → click alt → config placeholder renders → back → read-only refetches.
- No tests in repo; visual check requires a running browser.
